### PR TITLE
Related types creation bug

### DIFF
--- a/src/Bento.Core/Events/ContentServiceEvents.cs
+++ b/src/Bento.Core/Events/ContentServiceEvents.cs
@@ -87,8 +87,8 @@ namespace Bento.Core.Events
 					if (bentoBlocksRelationType == null)
 					{
 						RelationType relationType = new RelationType(
-							RelationTypes.BentoItemsAlias,
 							RelationTypes.BentoItemsName,
+							RelationTypes.BentoItemsAlias,
 							true,
 							UmbracoObjectTypes.Document.GetGuid(),
 							UmbracoObjectTypes.Document.GetGuid());


### PR DESCRIPTION
Fized a bug where newly created related types are added with the alias and name the wrong war round