### PR TITLE
generate layout aliases

### DIFF
--- a/src/Bento.Website/App_Plugins/Bento/PreValueEditors/bentolayout.edit.html
+++ b/src/Bento.Website/App_Plugins/Bento/PreValueEditors/bentolayout.edit.html
@@ -26,28 +26,34 @@
 							</label>
 							<div class="controls" id="layoutName">
 								<div class="umb-property-editor">
-									<div>
-
-										<input type="text" name="{{vm.model.name}}" class="umb-property-editor umb-textstring ng-scope" ng-model="vm.model.name" ng-change="vm.layoutChanged()" />
-
+									<div class="umb-editor-header__name-wrapper">
+										<input data-element="editor-name-field"
+										       no-password-manager
+										       type="text"
+										       id="name"
+										       class="umb-editor-header__name-input"
+										       localize="placeholder"
+										       placeholder="@placeholders_entername"
+										       name="vm.model.name"
+										       ng-model="vm.model.name"
+										       ng-class="{'name-is-empty': vm.model.name === null || vm.model.name === ''}"
+										       ng-change="vm.layoutChanged()"
+										       umb-auto-focus
+										       focus-on-filled="true"
+										       val-server-field="vm.model.name"
+										       required
+										       aria-required="true"
+										       autocomplete="off"
+										       maxlength="255" />
+										<umb-generate-alias data-element="editor-alias"
+										                    class="umb-panel-header-alias"
+										                    alias="vm.model.alias"
+										                    alias-from="vm.model.name"
+										                    enable-lock="true"
+										                    validation-position="'right'"
+										                    server-validation-field="Alias">
+										</umb-generate-alias>
 									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-
-					<div class="control-group umb-control-group">
-						<div class="umb-el-wrap">
-							<label class="control-label">
-								<localize key="bento_layoutAlias">Layout alias</localize> *
-							</label>
-							<div class="controls" id="layoutAlias">
-								<div class="umb-property-editor">
-
-									<div>
-										<input type="text" name="{{vm.model.alias}}" class="umb-property-editor umb-textstring" ng-model="vm.model.alias" ng-change="vm.layoutChanged()" />
-									</div>
-
 								</div>
 							</div>
 						</div>

--- a/src/Bento.Website/App_Plugins/Bento/PreValueEditors/bentolayoutarea.edit.html
+++ b/src/Bento.Website/App_Plugins/Bento/PreValueEditors/bentolayoutarea.edit.html
@@ -22,22 +22,33 @@
 							</label>
 							<div class="controls">
 								<div class="umb-property-editor">
-									<div>
-										<input type="text" name="{{vm.area.name}}" class="umb-property-editor umb-textstring" ng-model="vm.area.name" ng-change="vm.layoutChanged()" />
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-					<div class="control-group umb-control-group">
-						<div class="umb-el-wrap">
-							<label class="control-label">
-								<localize key="bento_areaAlias">Area alias</localize>
-							</label>
-							<div class="controls">
-								<div class="umb-property-editor">
-									<div>
-										<input type="text" name="{{vm.area.alias}}" class="umb-property-editor umb-textstring" ng-model="vm.area.alias" ng-change="vm.layoutChanged()" />
+									<div class="umb-editor-header__name-wrapper">
+										<input data-element="editor-name-field"
+										       no-password-manager
+										       type="text"
+										       id="name"
+										       class="umb-editor-header__name-input"
+										       localize="placeholder"
+										       placeholder="@placeholders_entername"
+										       name="vm.area.name"
+										       ng-model="vm.area.name"
+										       ng-class="{'name-is-empty': vm.area.name === null || vm.area.name === ''}"
+										       ng-change="vm.layoutChanged()"
+										       umb-auto-focus
+										       focus-on-filled="true"
+										       val-server-field="vm.area.name"
+										       required
+										       aria-required="true"
+										       autocomplete="off"
+										       maxlength="255" />
+										<umb-generate-alias data-element="editor-alias"
+										                    class="umb-panel-header-alias"
+										                    alias="vm.area.alias"
+										                    alias-from="vm.area.name"
+										                    enable-lock="true"
+										                    validation-position="'right'"
+										                    server-validation-field="Alias">
+										</umb-generate-alias>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
this update is off the back of issues #4 and #5 where it was suggested that aliases for layouts are areas could be auto generated

the code was lifted from the core and has the similar functionality as when creating a doctype:

![image](https://user-images.githubusercontent.com/22835873/106244558-d084b680-6256-11eb-83bc-9d392c9d0b6d.png)

it uses the 'umbGenerateAlias' directive:

[https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbGenerateAlias](https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbGenerateAlias)