### PR TITLE
Fix/content type picker fixes

### DIFF
--- a/src/Bento.Core/Bento.Core.csproj
+++ b/src/Bento.Core/Bento.Core.csproj
@@ -7,8 +7,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pluralize.NET" Version="1.0.2" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="12.1.1" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="12.1.1" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="12.3.3" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="12.3.3" />
 	</ItemGroup>
 
 </Project>

--- a/src/Bento.Core/Bento.Core.csproj
+++ b/src/Bento.Core/Bento.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
-		<Version>12.1.0</Version>
+		<Version>12.2.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Bento.Editor/App_Plugins/Bento/PreValueEditors/contenttypepicker.controller.js
+++ b/src/Bento.Editor/App_Plugins/Bento/PreValueEditors/contenttypepicker.controller.js
@@ -1,4 +1,4 @@
-﻿function ContentTypePickerController($scope, contentTypeResource, editorService, angularHelper) {
+﻿function ContentTypePickerController($scope, contentTypeResource, elementTypeResource, editorService, angularHelper) {
 	var vm = this;
 	vm.loading = false;
 	vm.contentTypes = [];
@@ -6,18 +6,25 @@
 	vm.add = add;
 	vm.hasValue = false;
 
-	var allContentTypes = null;
+	var allContentAndElementTypes = null;
 
 	function init() {
 		vm.loading = true;
 		vm.hasValue = $scope.model.value !== null && $scope.model.value !== "";
-		contentTypeResource.getAll().then(function (all) {
-			allContentTypes = all;
-			vm.loading = false;
-			// the model value is a comma separated list of content type aliases
-			var currentContentTypes = _.map(($scope.model.value || "").split(","), function (s) { return s.trim(); });
-			vm.contentTypes = _.filter(allContentTypes, function (contentType) {
-				return currentContentTypes.indexOf(contentType.alias) >= 0;
+		var allContentTypes = null;
+		var allElementTypes = null;
+		contentTypeResource.getAll().then(function (contentTypes) {
+			allContentTypes = contentTypes;
+			elementTypeResource.getAll().then(function (elementTypes) {
+				allElementTypes = elementTypes;
+				allContentAndElementTypes = allContentTypes.concat(allElementTypes);
+				// the model value is a comma separated list of content type aliases
+				var currentContentTypes = _.map(($scope.model.value || "").split(","), function (s) { return s.trim(); });
+				var contentTypes = _.filter(allContentAndElementTypes, function (contentType) {
+					return currentContentTypes.indexOf(contentType.alias) >= 0;
+				});
+				vm.contentTypes = contentTypes;
+				vm.loading = false;
 			});
 		});
 	}
@@ -27,7 +34,8 @@
 			multiPicker: true,
 			submit: function (model) {
 				var newContentTypes = _.map(model.selection, function (selected) {
-					return _.findWhere(allContentTypes, { udi: selected.udi });
+					//items return with a udi and a key, elements return with just a key - why?!?! they used to do both!
+					return _.findWhere(allContentAndElementTypes, { key: selected.key });
 				});
 				vm.contentTypes = _.uniq(_.union(vm.contentTypes, newContentTypes));
 				updateModel();

--- a/src/Bento.Editor/Bento.Editor.csproj
+++ b/src/Bento.Editor/Bento.Editor.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<Description>Bento Editor for Umbraco 12. A flexible block based editor that takes advantage of infinite editing.</Description>
-		<Version>12.1.0</Version>
+		<Version>12.2.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Bento.Website/App_Plugins/Bento/PreValueEditors/contenttypepicker.controller.js
+++ b/src/Bento.Website/App_Plugins/Bento/PreValueEditors/contenttypepicker.controller.js
@@ -1,4 +1,4 @@
-function ContentTypePickerController($scope, contentTypeResource, editorService, angularHelper) {
+function ContentTypePickerController($scope, contentTypeResource, elementTypeResource, editorService, angularHelper) {
 	var vm = this;
 	vm.loading = false;
 	vm.contentTypes = [];
@@ -6,18 +6,25 @@ function ContentTypePickerController($scope, contentTypeResource, editorService,
 	vm.add = add;
 	vm.hasValue = false;
 
-	var allContentTypes = null;
+	var allContentAndElementTypes = null;
 
 	function init() {
 		vm.loading = true;
 		vm.hasValue = $scope.model.value !== null && $scope.model.value !== "";
-		contentTypeResource.getAll().then(function (all) {
-			allContentTypes = all;
-			vm.loading = false;
-			// the model value is a comma separated list of content type aliases
-			var currentContentTypes = _.map(($scope.model.value || "").split(","), function (s) { return s.trim(); });
-			vm.contentTypes = _.filter(allContentTypes, function (contentType) {
-				return currentContentTypes.indexOf(contentType.alias) >= 0;
+		var allContentTypes = null;
+		var allElementTypes = null;
+		contentTypeResource.getAll().then(function (contentTypes) {
+			allContentTypes = contentTypes;
+			elementTypeResource.getAll().then(function (elementTypes) {
+				allElementTypes = elementTypes;
+				allContentAndElementTypes = allContentTypes.concat(allElementTypes);
+				// the model value is a comma separated list of content type aliases
+				var currentContentTypes = _.map(($scope.model.value || "").split(","), function (s) { return s.trim(); });
+				var contentTypes = _.filter(allContentAndElementTypes, function (contentType) {
+					return currentContentTypes.indexOf(contentType.alias) >= 0;
+				});
+				vm.contentTypes = contentTypes;
+				vm.loading = false;
 			});
 		});
 	}
@@ -27,7 +34,8 @@ function ContentTypePickerController($scope, contentTypeResource, editorService,
 			multiPicker: true,
 			submit: function (model) {
 				var newContentTypes = _.map(model.selection, function (selected) {
-					return _.findWhere(allContentTypes, { udi: selected.udi });
+					//items return with a udi and a key, elements return with just a key - why?!?! they used to do both!
+					return _.findWhere(allContentAndElementTypes, { key: selected.key });
 				});
 				vm.contentTypes = _.uniq(_.union(vm.contentTypes, newContentTypes));
 				updateModel();

--- a/src/Bento.Website/Bento.Website.csproj
+++ b/src/Bento.Website/Bento.Website.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms" Version="12.1.1" />
-		<PackageReference Include="Umbraco.Cms.Core" Version="12.1.1" />
+		<PackageReference Include="Umbraco.Cms" Version="12.3.3" />
+		<PackageReference Include="Umbraco.Cms.Core" Version="12.3.3" />
 		<ProjectReference Include="..\Bento.Core\Bento.Core.csproj" />
 		<RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
 	</ItemGroup>


### PR DESCRIPTION
it seems that between v12.1.1 and v12.3.3 the `contentTypeResource.getAll()` call has been changed to only return content (`IPublishedContent`) based doctypes (it used to return content and element types).

this update adds the `elementTypeResource.getAll()` call and combines the item and element types so the content picker works again.

ultimately, this will be replaced by a new picker but for the moment, this gets us something working for the current v12 projects.